### PR TITLE
Change node count and pods per node for super-large

### DIFF
--- a/dags/openshift_nightlies/releases/4.10/aws/ovn-superlarge-vzw/benchmarks.json
+++ b/dags/openshift_nightlies/releases/4.10/aws/ovn-superlarge-vzw/benchmarks.json
@@ -10,8 +10,8 @@
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
-                "PODS_PER_NODE": "250",
-                "NODE_COUNT": "120",
+                "PODS_PER_NODE": "50",
+                "NODE_COUNT": "500",
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",
@@ -28,8 +28,8 @@
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
-                "PODS_PER_NODE": "250",
-                "NODE_COUNT": "120",
+                "PODS_PER_NODE": "50",
+                "NODE_COUNT": "500",
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",


### PR DESCRIPTION
Making pods per node 50 to account for the 20 app pods
plus 30ish infra pods per node.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>